### PR TITLE
Fixes the namespacing that was mistakenly added for several files during the conversion.

### DIFF
--- a/health_metric_collector/include/health_metric_collector/collect_and_publish.h
+++ b/health_metric_collector/include/health_metric_collector/collect_and_publish.h
@@ -31,8 +31,8 @@ public:
    * @param c a list of metrics collectors.
    */
   CollectAndPublish(
-    std::shared_ptr<ros_monitoring_msgs::msg::MetricManagerInterface> mg,
-    std::vector<std::shared_ptr<ros_monitoring_msgs::msg::MetricCollectorInterface>> & c
+    std::shared_ptr<MetricManagerInterface> mg,
+    std::vector<std::shared_ptr<MetricCollectorInterface>> & c
     ) : mg_(mg), collectors_(c) {}
 
   /**
@@ -49,7 +49,7 @@ public:
   }
 
 private:
-  std::shared_ptr<ros_monitoring_msgs::msg::MetricManagerInterface> mg_;
-  const std::vector<std::shared_ptr<ros_monitoring_msgs::msg::MetricCollectorInterface>> &
+  std::shared_ptr<MetricManagerInterface> mg_;
+  const std::vector<std::shared_ptr<MetricCollectorInterface>> &
     collectors_;
 };

--- a/health_metric_collector/include/health_metric_collector/cpu_metric_collector.h
+++ b/health_metric_collector/include/health_metric_collector/cpu_metric_collector.h
@@ -21,8 +21,6 @@
 #include <health_metric_collector/metric_manager.h>
 
 
-namespace ros_monitoring_msgs {
-namespace msg {
 /**
  * collects cpu usage metric.
  */
@@ -34,7 +32,7 @@ public:
    *
    * @param m metric manager which creates and aggregates metrics.
    */
-  CPUMetricCollector(std::shared_ptr<ros_monitoring_msgs::msg::MetricManagerInterface> m)
+  CPUMetricCollector(std::shared_ptr<MetricManagerInterface> m)
     : MetricCollectorInterface(m) {}
 
   /**
@@ -49,5 +47,3 @@ private:
   std::shared_ptr<CPUStats> old_;
   std::shared_ptr<CPUStats> new_;
 };
-
-}}  // namespace ros_monitoring_msgs::msg

--- a/health_metric_collector/include/health_metric_collector/metric_collector.h
+++ b/health_metric_collector/include/health_metric_collector/metric_collector.h
@@ -17,9 +17,6 @@
 
 #include <health_metric_collector/metric_manager.h>
 
-namespace ros_monitoring_msgs {
-namespace msg {
-
 /**
  * @brief Interface for a metrics collector.
  */
@@ -30,7 +27,7 @@ public:
    * @brief Constructor.
    */
   MetricCollectorInterface(
-    std::shared_ptr<ros_monitoring_msgs::msg::MetricManagerInterface> mgr
+    std::shared_ptr<MetricManagerInterface> mgr
     ) : mgr_(mgr) {}
 
   /**
@@ -42,7 +39,5 @@ protected:
   /**
    * @brief creates metric entries and publishes them.
    */
-  std::shared_ptr<ros_monitoring_msgs::msg::MetricManagerInterface> mgr_;
+  std::shared_ptr<MetricManagerInterface> mgr_;
 };
-
-}}  // namespace ros_monitoring_msgs::msg

--- a/health_metric_collector/include/health_metric_collector/metric_manager.h
+++ b/health_metric_collector/include/health_metric_collector/metric_manager.h
@@ -22,8 +22,6 @@
 #include <vector>
 
 
-namespace ros_monitoring_msgs {
-namespace msg {
 /**
  * @brief Interface for MetricManager.
  */
@@ -37,14 +35,14 @@ public:
     /**
      * @brief create a metric.
      */
-    virtual MetricData CreateMetric() const = 0;
+    virtual ros_monitoring_msgs::msg::MetricData CreateMetric() const = 0;
 
     /**
      * @brief add a metric to list of metrics to be published.
      *
      * @param md a metric.
      */
-    virtual void AddMetric(MetricData md) = 0;
+    virtual void AddMetric(ros_monitoring_msgs::msg::MetricData md) = 0;
 
     /**
      * @brief publishes all metrics and then discards them.
@@ -66,21 +64,19 @@ public:
     int topic_buffer_size
     ) :
       node_(node),
-      publisher_(node->create_publisher<MetricList>(metrics_topic_name, topic_buffer_size)) {}
+      publisher_(node->create_publisher<ros_monitoring_msgs::msg::MetricList>(metrics_topic_name, topic_buffer_size)) {}
 
   virtual void AddDimension(const std::string &name, const std::string &value) override final;
 
-  virtual MetricData CreateMetric() const override final;
+  virtual ros_monitoring_msgs::msg::MetricData CreateMetric() const override final;
 
-  virtual void AddMetric(MetricData md) override final;
+  virtual void AddMetric(ros_monitoring_msgs::msg::MetricData md) override final;
 
   virtual void Publish() override final;
 
 private:
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Publisher<MetricList>::SharedPtr publisher_;
-  MetricList mlist_;
-  MetricData dimensions_;
+  rclcpp::Publisher<ros_monitoring_msgs::msg::MetricList>::SharedPtr publisher_;
+  ros_monitoring_msgs::msg::MetricList mlist_;
+  ros_monitoring_msgs::msg::MetricData dimensions_;
 };
-
-}}  // namespace ros_monitoring_msgs::msg

--- a/health_metric_collector/include/health_metric_collector/sys_info_collector.h
+++ b/health_metric_collector/include/health_metric_collector/sys_info_collector.h
@@ -19,8 +19,6 @@
 #include <health_metric_collector/metric_manager.h>
 
 
-namespace ros_monitoring_msgs {
-namespace msg {
 /**
  * @brief collects metrics from sysinfo.
  *
@@ -30,7 +28,7 @@ namespace msg {
 class SysInfoCollector : public MetricCollectorInterface
 {
 public:
-  SysInfoCollector(std::shared_ptr<ros_monitoring_msgs::msg::MetricManagerInterface> m)
+  SysInfoCollector(std::shared_ptr<MetricManagerInterface> m)
     : MetricCollectorInterface(m) {}
 
   void Collect() override final;
@@ -38,5 +36,3 @@ public:
 private:
   void AddMetric(const std::string & name, const double value, const std::string & unit);
 };
-
-}}  // namespace ros_monitoring_msgs::msg

--- a/health_metric_collector/src/collector.cpp
+++ b/health_metric_collector/src/collector.cpp
@@ -29,8 +29,8 @@
 
 
 using namespace Aws::Client;
-using namespace ros_monitoring_msgs::msg;
 using namespace std::chrono_literals;
+using namespace ros_monitoring_msgs::msg;
 
 
 #define DEFAULT_INTERVAL_SEC 5

--- a/health_metric_collector/src/cpu_metric_collector.cpp
+++ b/health_metric_collector/src/cpu_metric_collector.cpp
@@ -22,7 +22,6 @@
 
 using namespace ros_monitoring_msgs::msg;
 
-
 #define BASE_METRIC_NAME "cpu_usage_"
 
 

--- a/health_metric_collector/src/sys_info_collector.cpp
+++ b/health_metric_collector/src/sys_info_collector.cpp
@@ -22,7 +22,6 @@
 
 using namespace ros_monitoring_msgs::msg;
 
-
 #define MEGA (1000000)
 
 


### PR DESCRIPTION
Fixes the namespacing that was mistakenly added for several files during the conversion.

*Issue #, if available:*
Internal SIM: ROS-2687

*Description of changes:*
During the migration from ros1, a namespace was mistakenly added for several of the files/classes in this package. This change removes that namespace addition so that the namespace usage matches the ros1 package. 

*Testing:*
Tested on an X86 machine running inside a docker  image with ROS2 dashing installed from apt. With that setup I confirmed that the node was able to be launched with `ros2 launch` and that it was publishing to the metrics topic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
