### PR TITLE
Add unit tests (equivalent to the ROS1 version)

### DIFF
--- a/health_metric_collector/test/health_metric_collector_test.cpp
+++ b/health_metric_collector/test/health_metric_collector_test.cpp
@@ -19,12 +19,87 @@
 #include <health_metric_collector/metric_collector.h>
 #include <health_metric_collector/metric_manager.h>
 #include <health_metric_collector/sys_info_collector.h>
+#include <ros_monitoring_msgs/msg/metric_data.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <vector>
 
-TEST(CollectorSuite, empty)
+using namespace ros_monitoring_msgs::msg;
+using ::testing::Return;
+
+class MockMetricManager : public MetricManagerInterface
 {
+public:
+  MOCK_METHOD0(Publish, void());
+
+  MOCK_METHOD2(AddDimension, void(const std::string &, const std::string &));
+
+  MOCK_CONST_METHOD0(CreateMetric, MetricData());
+
+  MOCK_METHOD1(AddMetric, void(MetricData));
+};
+
+class MockMetricCollector : public MetricCollectorInterface
+{
+public:
+  MockMetricCollector(std::shared_ptr<MetricManagerInterface> m) : MetricCollectorInterface(m) {}
+  MOCK_METHOD0(Collect, void());
+};
+
+
+TEST(CollectorSuite, Child)
+{
+  auto mg = std::make_shared<MockMetricManager>();
+
+  std::vector<std::shared_ptr<MetricCollectorInterface>> collectors;
+  auto mc = std::make_shared<MockMetricCollector>(mg);
+  collectors.push_back(mc);
+
+  // start metrics collection
+  CollectAndPublish f(mg, collectors);
+
+  MetricData md;
+  ON_CALL(*mg, CreateMetric()).WillByDefault(Return(md));
+  EXPECT_CALL(*mg, Publish()).Times(1);
+  EXPECT_CALL(*mc, Collect()).Times(1);
+
+  f.Publish();
+}
+
+TEST(CollectorSuite, sysinfo)
+{
+  auto mg = std::make_shared<MockMetricManager>();
+  MetricData md;
+  ON_CALL(*mg, CreateMetric()).WillByDefault(Return(md));
+
+  EXPECT_CALL(*mg, AddMetric(testing::_)).Times(4);
+  SysInfoCollector sys_collector(mg);
+  sys_collector.Collect();
+}
+
+TEST(CollectorSuite, cpu_usage_0)
+{
+  auto mg = std::make_shared<MockMetricManager>();
+  MetricData md;
+  ON_CALL(*mg, CreateMetric()).WillByDefault(Return(md));
+
+  EXPECT_CALL(*mg, AddMetric(testing::_)).Times(0);
+
+  CPUMetricCollector cpu_collector(mg);
+  cpu_collector.Collect();
+}
+
+TEST(CollectorSuite, cpu_usage_1)
+{
+  auto mg = std::make_shared<MockMetricManager>();
+  MetricData md;
+  ON_CALL(*mg, CreateMetric()).WillByDefault(Return(md));
+
+  EXPECT_CALL(*mg, AddMetric(testing::_)).Times(testing::AtLeast(1));
+
+  CPUMetricCollector cpu_collector(mg);
+  cpu_collector.Collect();
+  cpu_collector.Collect();
 }
 
 int main(int argc, char ** argv)

--- a/health_metric_collector/test/test_health_metric_collector.test
+++ b/health_metric_collector/test/test_health_metric_collector.test
@@ -1,3 +1,0 @@
-<launch>
-    <test test-name="test_health_metric_collector" pkg="health_metric_collector" type="test_health_metric_collector"/>
-</launch>


### PR DESCRIPTION
Converting unit tests from the ROS1 version.

`colcon build --packages-select health_metric_collector && colcon test --packages-select health_metric_collector`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
