### PR TITLE
Update version to 3.0.0 for first ROS2 release

### DIFF
--- a/health_metric_collector/CHANGELOG.rst
+++ b/health_metric_collector/CHANGELOG.rst
@@ -8,3 +8,6 @@ Changelog for package health_metric_collector
   * Update to use non-legacy ParameterReader API
   * increment package version
 * Contributors: M. M
+
+1.0.0 (2019-03-20)
+------------------

--- a/health_metric_collector/package.xml
+++ b/health_metric_collector/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>health_metric_collector</name>
-  <version>2.0.1</version>
+  <version>3.0.0</version>
   <description>Package providing a ROS node for sending health metrics to Cloudwatch Metrics</description>
 
   <author email="ros-contributions@amazon.com">AWS RoboMaker</author>

--- a/health_metric_collector/package.xml
+++ b/health_metric_collector/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>health_metric_collector</name>
-  <version>1.0.0</version>
+  <version>2.0.1</version>
   <description>Package providing a ROS node for sending health metrics to Cloudwatch Metrics</description>
 
   <author email="ros-contributions@amazon.com">AWS RoboMaker</author>


### PR DESCRIPTION
Leaning towards doing this across the board, since releasing the CEs to Dashing using the same version numbers as our ROS1 CEs implies feature parity, which is what we're aiming for (and we can even keep the changelog in here). Let me know if you don't think it makes sense. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
